### PR TITLE
Verifica se o response não está vazio

### DIFF
--- a/src/Dooki/DookiResponse.php
+++ b/src/Dooki/DookiResponse.php
@@ -67,9 +67,11 @@ class DookiResponse
      */
     public function __construct($response)
     {
-        $response = json_decode($response, true);
 
-        $this->setResponse($response);
+        if (!empty($response)) {
+            $response = json_decode($response, true);
+            $this->setResponse($response);
+        }
 
         if (isset($response['meta'])) {
             $this->setMeta($response['meta']);

--- a/src/Dooki/DookiResponse.php
+++ b/src/Dooki/DookiResponse.php
@@ -67,7 +67,6 @@ class DookiResponse
      */
     public function __construct($response)
     {
-
         if (!empty($response)) {
             $response = json_decode($response, true);
             $this->setResponse($response);


### PR DESCRIPTION
Validação necessária quando a API retorna um response vazio. 